### PR TITLE
Do not run execution of cmd.aws.ec2.describeInstances in automated test

### DIFF
--- a/pkg/cmd/aws/ec2/describeInstances_test.go
+++ b/pkg/cmd/aws/ec2/describeInstances_test.go
@@ -23,7 +23,6 @@ THE SOFTWARE.
 package ec2
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,32 +39,23 @@ func init() {
 // to make sure it returns a valid command.
 func TestNewCmdDescribeInstances(t *testing.T) {
 	cases := map[string]struct {
-		use        string
-		short      string
-		hasFlags   bool
-		instanceId string
+		use      string
+		short    string
+		hasFlags bool
 	}{
 		"valid command": {
-			use:        "describeInstances [-i] [-a] [-b] [-s] [-m] [-r]",
-			short:      "Describe EC2 instances.",
-			hasFlags:   true,
-			instanceId: "i-1234567890abcdef0",
+			use:      "describeInstances [-i] [-a] [-b] [-s] [-m] [-r]",
+			short:    "Describe EC2 instances.",
+			hasFlags: true,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			oldArgs := os.Args
-			defer func() { os.Args = oldArgs }()
-			os.Args = []string{
-				"cmd",
-				"--instance-id", c.instanceId}
-
 			cmd := NewCmdDescribeInstances(nil)
 			assert.Equal(t, c.use, cmd.Use)
 			assert.Equal(t, c.short, cmd.Short)
 			assert.Equal(t, c.hasFlags, cmd.Flags().HasFlags())
-			assert.NoError(t, cmd.Execute())
 		})
 	}
 }


### PR DESCRIPTION
Resolve #99 